### PR TITLE
Redesign: clean dark productivity UI for Work Timer

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,9 +6,49 @@
 
 @theme {
   --breakpoint-vsm: 25rem;
+
+  --color-background: #0a0a0a;
+  --color-surface: #111111;
+  --color-surface-raised: #1a1a1a;
+  --color-border: #252525;
+  --color-foreground: #f5f5f5;
+  --color-muted: #777777;
+  --color-accent: #3b82f6;
+  --color-accent-hover: #2563eb;
+  --color-accent-muted: rgba(59, 130, 246, 0.12);
+  --color-success: #22c55e;
+  --color-warning: #f59e0b;
+
+  --font-sans: 'Nunito', sans-serif;
+
+  --radius-sm: 0.5rem;
+  --radius-md: 0.75rem;
+  --radius-lg: 1rem;
+  --radius-xl: 1.5rem;
+}
+
+html {
+  background-color: var(--color-background);
+  color: var(--color-foreground);
 }
 
 body {
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
+  background-color: var(--color-background);
+  color: var(--color-foreground);
+}
+
+/* Light mode overrides */
+.light body,
+[data-theme="light"] body {
+  --color-background: #f8f8f8;
+  --color-surface: #ffffff;
+  --color-surface-raised: #f0f0f0;
+  --color-border: #e4e4e4;
+  --color-foreground: #0a0a0a;
+  --color-muted: #888888;
+  --color-accent: #2563eb;
+  --color-accent-hover: #1d4ed8;
+  --color-accent-muted: rgba(37, 99, 235, 0.1);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,7 +28,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="pt-BR" suppressHydrationWarning>
+    <html lang="pt-BR" suppressHydrationWarning style={{ backgroundColor: '#0a0a0a' }}>
       <body className={`${nunito.variable} font-sans`}>
         <ThemeProvider>{children}</ThemeProvider>
         <Analytics />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,10 +4,12 @@ import { Navbar } from '@/components/Navbar'
 
 export default function Home() {
   return (
-    <main className="flex flex-col h-screen pt-16 pb-10">
+    <main className="flex flex-col min-h-screen pt-14 pb-12">
       <Navbar />
 
-      <MainForm />
+      <div className="flex flex-1 items-center justify-center py-8">
+        <MainForm />
+      </div>
 
       <Footer />
     </main>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,63 +4,66 @@ import { FC } from 'react'
 
 export const Footer: FC = () => {
   return (
-    <footer className="flex flex-1 space-x-4 bg-base-300 items-center justify-center px-4 py-2 w-full fixed bottom-0 inset-shadow-2xs">
-      <div className="avatar">
-        <div className="w-8 rounded-full">
-          <Image
-            src="https://avatars.githubusercontent.com/u/31856074?v=4"
-            alt="Hiroyuki Yamaguchi"
-            width={32}
-            height={32}
-          />
-        </div>
+    <footer
+      className="fixed bottom-0 left-0 right-0 flex items-center justify-center gap-4 px-6 h-12"
+      style={{
+        backgroundColor: 'var(--color-surface)',
+        borderTop: '1px solid var(--color-border)',
+      }}
+    >
+      <div
+        className="w-6 h-6 rounded-full overflow-hidden flex-shrink-0"
+        style={{ border: '1px solid var(--color-border)' }}
+      >
+        <Image
+          src="https://avatars.githubusercontent.com/u/31856074?v=4"
+          alt="Hiroyuki Yamaguchi"
+          width={24}
+          height={24}
+        />
       </div>
 
       <a
-        className="link"
+        className="text-xs font-medium transition-colors"
+        style={{ color: 'var(--color-muted)' }}
         target="_blank"
         aria-label="Hiroyuki Yamaguchi Portfolio"
         rel="noopener"
         href="https://hiroyamaguch.vercel.app/"
+        onMouseEnter={e => (e.currentTarget.style.color = 'var(--color-foreground)')}
+        onMouseLeave={e => (e.currentTarget.style.color = 'var(--color-muted)')}
       >
-        <p>Hiroyuki Yamaguchi</p>
+        Hiroyuki Yamaguchi
       </a>
 
-      <a
-        href="https://github.com/hiroyamaguch"
-        target="_blank"
-        aria-label="Hiroyuki Yamaguchi Github"
-        rel="noopener noreferrer"
-      >
-        <Github />
-      </a>
+      <div
+        className="h-3 w-px"
+        style={{ backgroundColor: 'var(--color-border)' }}
+        aria-hidden="true"
+      />
 
-      <a
-        href="https://instagram.com/hiroyamaguch/"
-        target="_blank"
-        aria-label="Hiroyuki Yamaguchi Instagram"
-        rel="noopener noreferrer"
-      >
-        <Instagram />
-      </a>
-
-      <a
-        href="https://linkedin.com/in/hiroyamaguch/"
-        target="_blank"
-        aria-label="Hiroyuki Yamaguchi LinkedIn"
-        rel="noopener noreferrer"
-      >
-        <Linkedin />
-      </a>
-
-      <a
-        href="mailto:hiroyamaguch@proton.me"
-        target="_blank"
-        aria-label="Hiroyuki Yamaguchi Email"
-        rel="noopener noreferrer"
-      >
-        <Mail />
-      </a>
+      <div className="flex items-center gap-3">
+        {[
+          { href: 'https://github.com/hiroyamaguch', Icon: Github, label: 'GitHub' },
+          { href: 'https://instagram.com/hiroyamaguch/', Icon: Instagram, label: 'Instagram' },
+          { href: 'https://linkedin.com/in/hiroyamaguch/', Icon: Linkedin, label: 'LinkedIn' },
+          { href: 'mailto:hiroyamaguch@proton.me', Icon: Mail, label: 'Email' },
+        ].map(({ href, Icon, label }) => (
+          <a
+            key={label}
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`Hiroyuki Yamaguchi ${label}`}
+            className="transition-colors"
+            style={{ color: 'var(--color-muted)' }}
+            onMouseEnter={e => (e.currentTarget.style.color = 'var(--color-foreground)')}
+            onMouseLeave={e => (e.currentTarget.style.color = 'var(--color-muted)')}
+          >
+            <Icon size={15} />
+          </a>
+        ))}
+      </div>
     </footer>
   )
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { Github, Instagram, Linkedin, Mail } from 'lucide-react'
 import Image from 'next/image'
 import { FC } from 'react'

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -4,20 +4,62 @@ import { twMerge } from 'tailwind-merge'
 
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   label: string
-  className?: HTMLAttributes<HTMLFieldSetElement>['className']
+  className?: HTMLAttributes<HTMLDivElement>['className']
   error?: FieldError | undefined
   icon?: ElementType
 }
 
 export const Input: FC<InputProps> = ({ label, className, icon: Icon, error, ...rest }) => {
   return (
-    <fieldset className={twMerge('fieldset not-md:w-51', className)}>
-      <legend className="fieldset-legend">{label}</legend>
-
-      <label className="input">
-        {Icon && <Icon />}
-        <input {...rest} className="block" aria-label={label} suppressHydrationWarning />
+    <div className={twMerge('flex flex-col gap-1.5', className)}>
+      <label
+        className="text-xs font-semibold uppercase tracking-widest"
+        style={{ color: 'var(--color-muted)' }}
+      >
+        {label}
       </label>
-    </fieldset>
+
+      <div
+        className="flex items-center gap-2 px-3 h-10 rounded-lg transition-all focus-within:outline-none"
+        style={{
+          backgroundColor: 'var(--color-surface-raised)',
+          border: '1px solid var(--color-border)',
+        }}
+        onFocus={e => {
+          const el = e.currentTarget as HTMLDivElement
+          el.style.borderColor = 'var(--color-accent)'
+          el.style.boxShadow = '0 0 0 3px var(--color-accent-muted)'
+        }}
+        onBlur={e => {
+          // only reset if focus moves outside this container
+          if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+            const el = e.currentTarget as HTMLDivElement
+            el.style.borderColor = 'var(--color-border)'
+            el.style.boxShadow = 'none'
+          }
+        }}
+      >
+        {Icon && (
+          <Icon
+            size={14}
+            style={{ color: 'var(--color-muted)', flexShrink: 0 }}
+            aria-hidden="true"
+          />
+        )}
+        <input
+          {...rest}
+          aria-label={label}
+          suppressHydrationWarning
+          className="flex-1 bg-transparent text-sm outline-none w-full min-w-0"
+          style={{ color: 'var(--color-foreground)' }}
+        />
+      </div>
+
+      {error && (
+        <span className="text-xs" style={{ color: 'var(--color-warning)' }}>
+          {error.message}
+        </span>
+      )}
+    </div>
   )
 }

--- a/src/components/MainForm.tsx
+++ b/src/components/MainForm.tsx
@@ -2,7 +2,7 @@
 
 import { yupResolver } from '@hookform/resolvers/yup'
 import { add, format } from 'date-fns'
-import { AlarmClockCheck, CalendarClock, Clock } from 'lucide-react'
+import { AlarmClockCheck, RotateCcw, Zap } from 'lucide-react'
 import type React from 'react'
 import { type ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react'
 import { type SubmitHandler, useForm } from 'react-hook-form'
@@ -12,6 +12,9 @@ import { Input } from './Input'
 
 const VALUES_LS_KEY = 'form-values'
 const VALUES_WDT_KEY = 'workday-time'
+
+const RADIUS = 52
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS
 
 export const MainForm: React.FC = () => {
   const [minutesLeft, setMinutesLeft] = useState<number>(480)
@@ -23,18 +26,19 @@ export const MainForm: React.FC = () => {
     reset,
     setValue,
     register,
-    formState: { errors }
+    formState: { errors },
   } = useForm({
     mode: 'all',
-    resolver: yupResolver(calcValidator)
+    resolver: yupResolver(calcValidator),
   })
 
   const percentage = useMemo(() => {
     const percentageLeft = (minutesLeft / workDayTime) * 100
-    const percentage = 100 - Math.round(percentageLeft)
-
-    return percentage
+    return Math.min(100, Math.max(0, 100 - Math.round(percentageLeft)))
   }, [minutesLeft, workDayTime])
+
+  const isOvertime = minutesLeft < 0
+  const isDone = minutesLeft <= 0
 
   const handleReset = useCallback(() => {
     setMinutesLeft(workDayTime)
@@ -44,124 +48,271 @@ export const MainForm: React.FC = () => {
 
   const handleChangeWorkDayTime = useCallback((event: ChangeEvent<HTMLInputElement>) => {
     const { value } = event.target
-
     localStorage.setItem(VALUES_WDT_KEY, value)
-
     setWorkDayTime(Number(value))
   }, [])
 
   const onSubmit: SubmitHandler<CalcInputsTypes> = (data) => {
     let totalHoursWorked = 0
-
     totalHoursWorked += calcDiferenceInMinutes(data.first, data?.second ?? '')
     totalHoursWorked += calcDiferenceInMinutes(data?.third ?? '', data?.fourth ?? '')
-
     setMinutesLeft(workDayTime - totalHoursWorked)
     setNow(new Date())
-
     localStorage.setItem(VALUES_LS_KEY, JSON.stringify(data))
   }
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: "This effect runs only once on mount."
   useEffect(() => {
     const workDayTimeOnLS = Number(localStorage?.getItem(VALUES_WDT_KEY) ?? 480)
-
     setMinutesLeft(workDayTimeOnLS)
     setWorkDayTime(workDayTimeOnLS)
 
     const data = localStorage.getItem(VALUES_LS_KEY)
-
     if (data) {
       const dataParsed = JSON.parse(data) as CalcInputsTypes
-
       setValue('first', dataParsed.first)
       setValue('second', dataParsed.second)
       setValue('third', dataParsed.third)
       setValue('fourth', dataParsed.fourth)
-
       onSubmit(dataParsed)
     } else {
       setNow(new Date())
     }
   }, [setValue])
 
+  const strokeDashoffset = CIRCUMFERENCE - (percentage / 100) * CIRCUMFERENCE
+  const ringColor = isDone
+    ? 'var(--color-success)'
+    : percentage > 75
+      ? 'var(--color-accent)'
+      : 'var(--color-accent)'
+
+  const displayMinutes = isDone
+    ? Math.abs(minutesLeft) + (isOvertime ? workDayTime - workDayTime : 0)
+    : minutesLeft
+
+  const estimatedEnd =
+    !isDone && now ? format(add(now, { minutes: minutesLeft }), 'HH:mm') : null
+
   return (
-    <div className="flex flex-col space-y-6 items-center max-w-330 w-full justify-center m-auto px-4 py-4 pb-10">
-      <form
-        id="calc-hours"
-        onSubmit={handleSubmit(onSubmit)}
-        className="flex w-full not-md:items-center md:justify-center space-x-2 not-md:flex-col"
-        suppressHydrationWarning
+    <div
+      className="flex flex-col items-center gap-6 w-full max-w-2xl mx-auto px-4 py-6"
+      suppressHydrationWarning
+    >
+      {/* Stats card */}
+      <div
+        className="w-full rounded-xl p-6 flex flex-col sm:flex-row items-center gap-6"
+        style={{
+          backgroundColor: 'var(--color-surface)',
+          border: '1px solid var(--color-border)',
+        }}
       >
-        <Input
-          className="max-w-51"
-          label="Workday time (in min)"
-          type="number"
-          placeholder="480"
-          required
-          icon={AlarmClockCheck}
-          value={workDayTime}
-          error={errors?.['work-day-time']}
-          {...register('work-day-time', { onChange: handleChangeWorkDayTime })}
-        />
-
-        <Input label="First Check-in" type="time" error={errors?.first} {...register('first')} />
-
-        <Input label="Dinner Checkout" type="time" error={errors?.second} {...register('second')} />
-
-        <Input label="Second Check-in" type="time" error={errors?.third} {...register('third')} />
-
-        <Input label="Work day end" type="time" error={errors?.fourth} {...register('fourth')} />
-      </form>
-
-      <div className="flex items-end space-x-2">
-        <button
-          type="submit"
-          form="calc-hours"
-          className="h-9 btn btn-primary"
-          suppressHydrationWarning
-        >
-          Calculate
-        </button>
-
-        <button className="h-9 btn btn-secondary" type="reset" onClick={handleReset}>
-          Clean
-        </button>
-      </div>
-
-      <div className="stats shadow max-vsm:stats-vertical">
-        <div className="stat">
-          <div className="stat-figure text-primary">
-            <Clock />
-          </div>
-          <div className="stat-title">{percentage < 100 ? 'Left' : 'Time Worked'}</div>
-          <div className="stat-value text-primary">
-            {percentage < 100 ? minutesLeft : minutesLeft * -1 + workDayTime} min
-          </div>
-          <div className="stat-desc">
-            {percentage < 100
-              ? `of the ${workDayTime} min goal`
-              : `${minutesLeft * -1} min of overtime`}
+        {/* Circular progress */}
+        <div className="relative flex-shrink-0 flex items-center justify-center" aria-hidden="true">
+          <svg width="128" height="128" viewBox="0 0 128 128">
+            {/* Track */}
+            <circle
+              cx="64"
+              cy="64"
+              r={RADIUS}
+              fill="none"
+              stroke="var(--color-border)"
+              strokeWidth="8"
+            />
+            {/* Progress */}
+            <circle
+              cx="64"
+              cy="64"
+              r={RADIUS}
+              fill="none"
+              stroke={ringColor}
+              strokeWidth="8"
+              strokeLinecap="round"
+              strokeDasharray={CIRCUMFERENCE}
+              strokeDashoffset={strokeDashoffset}
+              transform="rotate(-90 64 64)"
+              style={{ transition: 'stroke-dashoffset 0.6s ease, stroke 0.3s ease' }}
+            />
+          </svg>
+          <div className="absolute inset-0 flex flex-col items-center justify-center">
+            <span
+              className="text-3xl font-bold tabular-nums leading-none"
+              style={{ color: isDone ? 'var(--color-success)' : 'var(--color-foreground)' }}
+            >
+              {percentage}%
+            </span>
+            <span className="text-xs mt-1" style={{ color: 'var(--color-muted)' }}>
+              done
+            </span>
           </div>
         </div>
 
-        <div className="stat">
-          <div className="stat-figure text-secondary">
-            <CalendarClock />
+        {/* Stats text */}
+        <div className="flex-1 flex flex-col gap-4 w-full">
+          {isDone ? (
+            <div className="flex flex-col gap-1">
+              <span className="text-xs font-semibold uppercase tracking-widest" style={{ color: 'var(--color-success)' }}>
+                Work Done
+              </span>
+              <span className="text-4xl font-bold" style={{ color: 'var(--color-success)' }}>
+                Good work! 🎉
+              </span>
+              {isOvertime && (
+                <span className="text-sm" style={{ color: 'var(--color-muted)' }}>
+                  +{Math.abs(minutesLeft)} min of overtime
+                </span>
+              )}
+            </div>
+          ) : (
+            <div className="flex flex-col gap-1">
+              <span
+                className="text-xs font-semibold uppercase tracking-widest"
+                style={{ color: 'var(--color-muted)' }}
+              >
+                Time Left
+              </span>
+              <span
+                className="text-4xl font-bold tabular-nums"
+                style={{ color: 'var(--color-foreground)' }}
+              >
+                {minutesLeft}{' '}
+                <span className="text-xl font-medium" style={{ color: 'var(--color-muted)' }}>
+                  min
+                </span>
+              </span>
+              <span className="text-sm" style={{ color: 'var(--color-muted)' }}>
+                of {workDayTime} min goal
+              </span>
+            </div>
+          )}
+
+          {estimatedEnd && (
+            <div
+              className="flex items-center gap-2 rounded-lg px-3 py-2 w-fit"
+              style={{
+                backgroundColor: 'var(--color-accent-muted)',
+                border: '1px solid rgba(59,130,246,0.2)',
+              }}
+            >
+              <span
+                className="text-xs font-semibold uppercase tracking-widest"
+                style={{ color: 'var(--color-accent)' }}
+              >
+                Est. end
+              </span>
+              <span
+                className="text-lg font-bold tabular-nums"
+                style={{ color: 'var(--color-accent)' }}
+              >
+                {estimatedEnd}
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Form card */}
+      <div
+        className="w-full rounded-xl p-6"
+        style={{
+          backgroundColor: 'var(--color-surface)',
+          border: '1px solid var(--color-border)',
+        }}
+      >
+        <form
+          id="calc-hours"
+          onSubmit={handleSubmit(onSubmit)}
+          suppressHydrationWarning
+          className="flex flex-col gap-5"
+        >
+          {/* Workday time - full width */}
+          <Input
+            label="Workday duration (min)"
+            type="number"
+            placeholder="480"
+            required
+            icon={AlarmClockCheck}
+            value={workDayTime}
+            error={errors?.['work-day-time']}
+            {...register('work-day-time', { onChange: handleChangeWorkDayTime })}
+          />
+
+          {/* Time inputs in a 2-col or 4-col grid */}
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+            <Input
+              label="First Check-in"
+              type="time"
+              error={errors?.first}
+              {...register('first')}
+            />
+            <Input
+              label="Dinner Checkout"
+              type="time"
+              error={errors?.second}
+              {...register('second')}
+            />
+            <Input
+              label="Second Check-in"
+              type="time"
+              error={errors?.third}
+              {...register('third')}
+            />
+            <Input
+              label="Work Day End"
+              type="time"
+              error={errors?.fourth}
+              {...register('fourth')}
+            />
           </div>
-          <div className="stat-title">
-            {percentage < 100 ? 'Estimated end of work' : 'Work Done :)'}
-          </div>
-          <div className="stat-value text-secondary">
-            {percentage < 100
-              ? now
-                ? format(add(now, { minutes: minutesLeft }), 'HH:mm')
-                : '--:--'
-              : '--:--'}
-          </div>
-          <div className="stat-desc">
-            {percentage < 100 ? `${percentage}% concluded` : 'Good Work!'}
-          </div>
+        </form>
+
+        {/* Actions */}
+        <div className="flex items-center gap-3 mt-5">
+          <button
+            type="submit"
+            form="calc-hours"
+            className="flex items-center gap-2 px-5 py-2 rounded-lg text-sm font-semibold transition-all"
+            style={{
+              backgroundColor: 'var(--color-accent)',
+              color: '#ffffff',
+            }}
+            onMouseEnter={e =>
+              ((e.currentTarget as HTMLButtonElement).style.backgroundColor =
+                'var(--color-accent-hover)')
+            }
+            onMouseLeave={e =>
+              ((e.currentTarget as HTMLButtonElement).style.backgroundColor =
+                'var(--color-accent)')
+            }
+            suppressHydrationWarning
+          >
+            <Zap size={14} />
+            Calculate
+          </button>
+
+          <button
+            type="reset"
+            onClick={handleReset}
+            className="flex items-center gap-2 px-5 py-2 rounded-lg text-sm font-semibold transition-all"
+            style={{
+              backgroundColor: 'var(--color-surface-raised)',
+              color: 'var(--color-muted)',
+              border: '1px solid var(--color-border)',
+            }}
+            onMouseEnter={e => {
+              const btn = e.currentTarget as HTMLButtonElement
+              btn.style.color = 'var(--color-foreground)'
+              btn.style.borderColor = 'var(--color-muted)'
+            }}
+            onMouseLeave={e => {
+              const btn = e.currentTarget as HTMLButtonElement
+              btn.style.color = 'var(--color-muted)'
+              btn.style.borderColor = 'var(--color-border)'
+            }}
+          >
+            <RotateCcw size={14} />
+            Reset
+          </button>
         </div>
       </div>
     </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -5,10 +5,22 @@ import { ToggleThemeModeButton } from './ToggleThemeModeButton'
 
 export const Navbar: FC = () => {
   return (
-    <header className="navbar bg-base-300 shadow-sm fixed top-0 z-50 flex items-center justify-between px-4 h-16">
-      <Image alt="Work Timer Logo" title="Work Timer" src={logo} height={48} width={48}></Image>
-
-      <h1>Work Timer</h1>
+    <header
+      className="fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-6 h-14"
+      style={{
+        backgroundColor: 'var(--color-surface)',
+        borderBottom: '1px solid var(--color-border)',
+      }}
+    >
+      <div className="flex items-center gap-2.5">
+        <Image alt="Work Timer Logo" title="Work Timer" src={logo} height={28} width={28} />
+        <span
+          className="text-sm font-semibold tracking-tight"
+          style={{ color: 'var(--color-foreground)' }}
+        >
+          Work Timer
+        </span>
+      </div>
 
       <ToggleThemeModeButton />
     </header>


### PR DESCRIPTION
## Redesign

Completely redesigns the Work Timer app with a minimal, dark-first productivity aesthetic while preserving all existing logic.

### Changes

- **`globals.css`** — new design token system (`--color-background`, `--color-surface`, `--color-accent`, etc.) replacing DaisyUI classes
- **`Navbar`** — slimmer 14px height bar with logo + title + theme toggle, clean border-bottom
- **`Footer`** — compact fixed footer with smaller avatar, muted social links
- **`Input`** — custom styled input with focus ring using accent tokens (no more fieldset/DaisyUI)
- **`MainForm`** — redesigned into two cards:
  - **Stats card**: animated SVG circular progress ring + large time-left readout + estimated end-of-day badge
  - **Form card**: responsive 2→4 column grid for time inputs + styled Calculate/Reset buttons
- **`page.tsx`** — centered layout with proper `pt-14 pb-12` spacing for fixed nav/footer