### PR TITLE
Remove 'done' text from circular progress

### DIFF
--- a/src/components/MainForm.tsx
+++ b/src/components/MainForm.tsx
@@ -141,9 +141,7 @@ export const MainForm: React.FC = () => {
             >
               {percentage}%
             </span>
-            <span className="text-xs mt-1" style={{ color: 'var(--color-muted)' }}>
-              done
-            </span>
+
           </div>
         </div>
 


### PR DESCRIPTION
Removes the `<span>` with the text "done" displayed below the percentage inside the circular progress indicator in the stats card.