### PR TITLE
feat: browser notification when work goal is reached

### DIFF
--- a/src/components/MainForm.tsx
+++ b/src/components/MainForm.tsx
@@ -28,6 +28,7 @@ export const MainForm: React.FC<MainFormProps> = ({ realtimeEnabled }) => {
   const [realtimeMode, setRealtimeMode] = useState<boolean>(false)
   const [lastCalculatedAt, setLastCalculatedAt] = useState<Date | null>(null)
   const [baseMinutesLeft, setBaseMinutesLeft] = useState<number>(480)
+  const [notificationFired, setNotificationFired] = useState<boolean>(false)
 
   const {
     handleSubmit,
@@ -60,6 +61,22 @@ export const MainForm: React.FC<MainFormProps> = ({ realtimeEnabled }) => {
     setWorkDayTime(Number(value))
   }, [])
 
+  const requestNotificationPermission = useCallback(async () => {
+    if (!('Notification' in window)) return
+    if (Notification.permission === 'default') {
+      await Notification.requestPermission()
+    }
+  }, [])
+
+  const fireWorkDoneNotification = useCallback(() => {
+    if (!('Notification' in window)) return
+    if (Notification.permission !== 'granted') return
+    new Notification('Quanto Falta? ✅', {
+      body: 'Meta de trabalho atingida! Bom trabalho! 🎉',
+      icon: '/favicon.ico',
+    })
+  }, [])
+
   const onSubmit: SubmitHandler<CalcInputsTypes> = (data) => {
     let totalHoursWorked = 0
     totalHoursWorked += calcDiferenceInMinutes(data.first, data?.second ?? '')
@@ -69,7 +86,9 @@ export const MainForm: React.FC<MainFormProps> = ({ realtimeEnabled }) => {
     setBaseMinutesLeft(calculatedMinutes)
     setLastCalculatedAt(new Date())
     setNow(new Date())
+    setNotificationFired(false) // reset so a new notification can fire for the new submission
     localStorage.setItem(VALUES_LS_KEY, JSON.stringify(data))
+    requestNotificationPermission()
   }
 
   const toggleRealtimeMode = useCallback(() => {
@@ -101,6 +120,14 @@ export const MainForm: React.FC<MainFormProps> = ({ realtimeEnabled }) => {
       setNow(new Date())
     }
   }, [setValue])
+
+  // Fire browser notification when work goal is reached
+  useEffect(() => {
+    if (minutesLeft <= 0 && !notificationFired && lastCalculatedAt !== null) {
+      fireWorkDoneNotification()
+      setNotificationFired(true)
+    }
+  }, [minutesLeft, notificationFired, lastCalculatedAt, fireWorkDoneNotification])
 
   // Real-time mode: update minutes left every minute (only when feature flag is enabled)
   useEffect(() => {

--- a/src/components/MainForm.tsx
+++ b/src/components/MainForm.tsx
@@ -88,8 +88,13 @@ export const MainForm: React.FC<MainFormProps> = ({ realtimeEnabled }) => {
     setNow(new Date())
     setNotificationFired(false) // reset so a new notification can fire for the new submission
     localStorage.setItem(VALUES_LS_KEY, JSON.stringify(data))
-    requestNotificationPermission()
   }
+
+  // Wrapper for form submission that also requests notification permission (user gesture only)
+  const handleFormSubmit = handleSubmit((data) => {
+    onSubmit(data)
+    requestNotificationPermission()
+  })
 
   const toggleRealtimeMode = useCallback(() => {
     setRealtimeMode((prev) => {
@@ -291,7 +296,7 @@ export const MainForm: React.FC<MainFormProps> = ({ realtimeEnabled }) => {
       >
         <form
           id="calc-hours"
-          onSubmit={handleSubmit(onSubmit)}
+          onSubmit={handleFormSubmit}
           suppressHydrationWarning
           className="flex flex-col gap-5"
         >

--- a/src/components/MainForm.tsx
+++ b/src/components/MainForm.tsx
@@ -68,13 +68,14 @@ export const MainForm: React.FC<MainFormProps> = ({ realtimeEnabled }) => {
     }
   }, [])
 
-  const fireWorkDoneNotification = useCallback(() => {
-    if (!('Notification' in window)) return
-    if (Notification.permission !== 'granted') return
-    new Notification('Quanto Falta? ✅', {
-      body: 'Meta de trabalho atingida! Bom trabalho! 🎉',
+  const fireWorkDoneNotification = useCallback((): boolean => {
+    if (!('Notification' in window)) return false
+    if (Notification.permission !== 'granted') return false
+    new Notification('Quanto Falta?', {
+      body: 'Meta de trabalho atingida! Bom trabalho!',
       icon: '/favicon.ico',
     })
+    return true
   }, [])
 
   const onSubmit: SubmitHandler<CalcInputsTypes> = (data) => {
@@ -129,8 +130,10 @@ export const MainForm: React.FC<MainFormProps> = ({ realtimeEnabled }) => {
   // Fire browser notification when work goal is reached
   useEffect(() => {
     if (minutesLeft <= 0 && !notificationFired && lastCalculatedAt !== null) {
-      fireWorkDoneNotification()
-      setNotificationFired(true)
+      const wasFired = fireWorkDoneNotification()
+      if (wasFired) {
+        setNotificationFired(true)
+      }
     }
   }, [minutesLeft, notificationFired, lastCalculatedAt, fireWorkDoneNotification])
 


### PR DESCRIPTION
## Summary

Adds a browser Notification API integration to alert the user when the work time goal is reached.

### Changes in `MainForm.tsx`
- Added `notificationFired` state to ensure the notification fires only once per calculation.
- Added `requestNotificationPermission` — called on form submit to ask for notification permission upfront.
- Added `fireWorkDoneNotification` — creates a `Notification` with a friendly message.
- Added a `useEffect` that watches `minutesLeft`: when it reaches `≤ 0` and the notification hasn't been fired yet (and there's an active calculation), it fires the notification and sets the flag.
- On each new form submission, `notificationFired` is reset so the notification can fire again for the new session.